### PR TITLE
Sandboxie support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _ReSharper*/
 $tf*/
 *.sdf
 *.opt
+*.swp/
+**/*.swp

--- a/LoaderDll/LoaderDll.cpp
+++ b/LoaderDll/LoaderDll.cpp
@@ -207,6 +207,12 @@ LeCreateProcess(
 
 	ULONG_PTR Length = (StrLengthW(DllFullPath) + 1) * sizeof(WCHAR);
 	CopyMemory(LePeb->LeDllFullPath, DllFullPath, ML_MIN(Length, sizeof(LePeb->LeDllFullPath)));
+
+  Length = Module->FullDllName.Length + sizeof(WCHAR) - Module->BaseDllName.Length;
+
+  Length = ML_MIN(Length, sizeof(LePeb->LeDllFullPath));
+  CopyMemory(LePeb->LeDllDirPath, Module->FullDllName.Buffer, Length);
+  LePeb->LeDllDirPath[Length / sizeof(WCHAR) - 1] = 0;
 	}
 
 	UNICODE_STRING DllFullPathString;

--- a/LocaleEmulator/Hooks/User32Hook.cpp
+++ b/LocaleEmulator/Hooks/User32Hook.cpp
@@ -39,9 +39,14 @@ UserMessageCall(INLPCREATESTRUCT)
 
     SEH_TRY
     {
-        PCBT_CREATE_PARAM CbtCreateParam = (PCBT_CREATE_PARAM)CreateStructW->lpCreateParams;
-        if (CbtCreateParam->Magic == CBT_PROC_PARAM_CONTEXT)
-            CreateStructW->lpCreateParams = CbtCreateParam->CreateParams;
+        LOOP_ONCE
+        {
+            if (!CreateStructW) break;
+            PCBT_CREATE_PARAM CbtCreateParam = (PCBT_CREATE_PARAM)CreateStructW->lpCreateParams;
+            if (!CbtCreateParam) break;
+            if (CbtCreateParam->Magic == CBT_PROC_PARAM_CONTEXT)
+                CreateStructW->lpCreateParams = CbtCreateParam->CreateParams;
+        }
     }
     SEH_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -656,6 +661,8 @@ BOOL VerifyWindowParam(PCBT_CREATE_PARAM CbtCreateParam, PCBT_PROC_PARAM CbtPara
 {
     SEH_TRY
     {
+        // FIXME: SEH DOESN'T work
+        if (!CbtCreateParam || !CbtParam) return FALSE;
         return CbtCreateParam->StackPointer == CbtParam->StackPointer;
     }
     SEH_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
@@ -1205,7 +1212,7 @@ PVOID FindNtUserMessageCall2(PVOID User32)
                             SEH_TRY
                             {
                                 Buffer = GetCallDestination(Buffer);
-                                if (IsSystemCall(Buffer) == FALSE)
+                                if (!Buffer || IsSystemCall(Buffer) == FALSE)
                                     break;
                             }
                             SEH_EXCEPT(EXCEPTION_EXECUTE_HANDLER)

--- a/LocaleEmulator/ml.h
+++ b/LocaleEmulator/ml.h
@@ -11169,6 +11169,11 @@ typedef struct
 
 #define DIRECTORY_ALL_ACCESS (STANDARD_RIGHTS_REQUIRED | 0xF)
 
+typedef struct _DIRECTORY_BASIC_INFORMATION {
+    UNICODE_STRING ObjectName;
+    UNICODE_STRING ObjectTypeName;
+} DIRECTORY_BASIC_INFORMATION, *PDIRECTORY_BASIC_INFORMATION;
+
 //begin_winnt
 
 //
@@ -12759,6 +12764,32 @@ ZwOpenDirectoryObject(
     OUT PHANDLE             DirectoryHandle,
     IN  ACCESS_MASK         DesiredAccess,
     IN  POBJECT_ATTRIBUTES  ObjectAttributes
+);
+
+NATIVE_API
+NTSTATUS
+NTAPI
+NtQueryDirectoryObject(
+    HANDLE  DirectoryHandle,
+    PVOID   Buffer,
+    ULONG   Length,
+    BOOLEAN ReturnSingleEntry,
+    BOOLEAN RestartScan,
+    PULONG  Context,
+    PULONG  ReturnLength
+);
+
+NATIVE_API
+NTSTATUS
+NTAPI
+ZwQueryDirectoryObject(
+    HANDLE  DirectoryHandle,
+    PVOID   Buffer,
+    ULONG   Length,
+    BOOLEAN ReturnSingleEntry,
+    BOOLEAN RestartScan,
+    PULONG  Context,
+    PULONG  ReturnLength
 );
 
 NATIVE_API


### PR DESCRIPTION
# Description
It is usually a good practice to run untrusted programs in restricted environment such as Sandboxie. 

However, there are some different behaviors that makes LE doesn't work in sandboxie:

1. Sandboxie's implementation of `LdrLoadDll` loads kernel32 first, so LE will be initialized after kernel32 loaded.
2. Peb path is prefixed with `\\Sandbox`.

This pull request try to deal with them.

# Changes
1. Initialize the injected dll instead of loading dll again.
2. If Peb is not found at default location, try to traverse `\\Sandbox` sections to find it.

# Side effect
When creating logfile in injected process, dll path is unavailable because it is not loaded. I store the path in peb instead.

# Test
Tested with Sandboxie 5.26