### PR TITLE
workaround for >=10.21390.2025

### DIFF
--- a/LocaleEmulator/Hooks/Gdi32Hook.cpp
+++ b/LocaleEmulator/Hooks/Gdi32Hook.cpp
@@ -3,70 +3,6 @@
 
 ULONG (NTAPI *GdiGetCodePage)(HDC NewDC);
 
-/*
-HFONT
-NTAPI
-LeNtGdiHfontCreate(
-    PENUMLOGFONTEXDVW   EnumLogFont,
-    ULONG               SizeOfEnumLogFont,
-    LONG                LogFontType,
-    LONG                Unknown,
-    PVOID               FreeListLocalFont
-);
-
-HFONT
-WINAPI
-LeCreateFontIndirectExW(const ENUMLOGFONTEXDVW* elfexd)
-{
-    // Msdn: Note, this function ignores the elfDesignVector member in ENUMLOGFONTEXDV.
-    if (elfexd)
-    {
-        PLeGlobalData       GlobalData = LeGetGlobalData();
-        //return GlobalData->HookStub.StubNtGdiHfontCreate((PENUMLOGFONTEXDVW)elfexd, 0, 0, 0, NULL);
-        return LeNtGdiHfontCreate((PENUMLOGFONTEXDVW)elfexd, 0, 0, 0, NULL);
-    }
-    else return NULL;
-}
-
-
-HFONT
-WINAPI
-LeCreateFontIndirectW(
-    CONST LOGFONTW* lplf
-)
-{
-#if 0
-    static BOOL bDidTest = FALSE;
-    if (!bDidTest)
-    {
-        bDidTest = TRUE;
-        DoFontSystemUnittest();
-    }
-#endif
-    if (lplf)
-    {
-        ENUMLOGFONTEXDVW Logfont;
-
-        RtlCopyMemory(&Logfont.elfEnumLogfontEx.elfLogFont, lplf, sizeof(LOGFONTW));
-        // Need something other than just cleaning memory here.
-        // Guess? Use caller data to determine the rest.
-        RtlZeroMemory(&Logfont.elfEnumLogfontEx.elfFullName,
-            sizeof(Logfont.elfEnumLogfontEx.elfFullName));
-        RtlZeroMemory(&Logfont.elfEnumLogfontEx.elfStyle,
-            sizeof(Logfont.elfEnumLogfontEx.elfStyle));
-        RtlZeroMemory(&Logfont.elfEnumLogfontEx.elfScript,
-            sizeof(Logfont.elfEnumLogfontEx.elfScript));
-
-        Logfont.elfDesignVector.dvNumAxes = 0; // No more than MM_MAX_NUMAXES
-
-        RtlZeroMemory(&Logfont.elfDesignVector, sizeof(DESIGNVECTOR));
-
-        return LeCreateFontIndirectExW(&Logfont);
-    }
-    else return NULL;
-}
-*/
-
 HFONT GetFontFromFont(PLeGlobalData GlobalData, HFONT Font)
 {
     LOGFONTW LogFont;
@@ -75,7 +11,6 @@ HFONT GetFontFromFont(PLeGlobalData GlobalData, HFONT Font)
         return nullptr;
 
     LogFont.lfCharSet = GlobalData->GetLeb()->DefaultCharset;
-    //Font = LeCreateFontIndirectW(&LogFont);
     Font = CreateFontIndirectW(&LogFont);
 
     return Font;
@@ -803,7 +738,7 @@ LeNtGdiHfontCreate(
         //if (GdiGetCodePage == NULL)
         //CopyStruct(enumlfex->elfEnumLogfontEx.elfLogFont.lfFaceName, GlobalData->GetLeb()->DefaultFaceName, LF_FACESIZE);
         //AllocConsole();
-        //PrintConsoleW(L"%d=>%d %s\n", Charset, enumlfex->elfEnumLogfontEx.elfLogFont.lfCharSet, enumlfex->elfEnumLogfontEx.elfLogFont.lfFaceName);
+        //PrintConsoleW(L"%s\n", enumlfex.elfEnumLogfontEx.elfLogFont.lfFaceName);
 
         EnumLogFont = enumlfex;
     }

--- a/LocaleEmulator/Hooks/Kernel32Hook.cpp
+++ b/LocaleEmulator/Hooks/Kernel32Hook.cpp
@@ -158,6 +158,17 @@ void* GetKthCallTarget(void* start_offset, DWORD parse_range_each, int K) {
 typedef DWORD(__stdcall* pSetupAnsiOemCodeHashNodes)();
 
 NTSTATUS LeSetupAnsiOemCodeHashNodes() {
+
+    RTL_OSVERSIONINFOW osvi;
+
+    ZeroMemory(&osvi, sizeof(RTL_OSVERSIONINFOW));
+    osvi.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
+
+    RtlGetVersion(&osvi);
+    if (osvi.dwMajorVersion < 10 || osvi.dwBuildNumber < 19042)
+        return STATUS_SUCCESS; // does not need this trick for older versions.
+
+
     PLDR_MODULE Kernel = FindLdrModuleByName(&USTR(L"KERNELBASE.dll"));
     if (Kernel == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;

--- a/LocaleEmulator/Hooks/Kernel32Hook.cpp
+++ b/LocaleEmulator/Hooks/Kernel32Hook.cpp
@@ -141,9 +141,10 @@ void* GetFirstCallTarget(void* start_offset, DWORD parse_range, void **next) {
 }
 
 void* GetKthCallTarget(void* start_offset, DWORD parse_range_each, int K) {
+// returns nullptr if K == 0
     if (start_offset == nullptr)
         return nullptr;
-    void *next, *res;
+    void *next, *res = nullptr;
     while (K >= 1) {
         res = GetFirstCallTarget(start_offset, parse_range_each, &next);
         if (res == nullptr)
@@ -165,12 +166,13 @@ NTSTATUS LeSetupAnsiOemCodeHashNodes() {
     if (pKernelBaseDllInitialize == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;
 
+    WriteLog(L"KernelBaseDllInitialize: %p\n", pKernelBaseDllInitialize);
+
     void* pKernelBaseBaseDllInitialize = GetKthCallTarget(pKernelBaseDllInitialize, 0x20, 2);
     if (pKernelBaseBaseDllInitialize == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;
 
-    //AllocConsole();
-    //PrintConsoleW(L"pKernelBaseDllInitialize = %p\npKernelBaseBaseDllInitialize: %p\n", pKernelBaseDllInitialize, pKernelBaseBaseDllInitialize);
+    WriteLog(L"KernelBaseBaseDllInitialize: %p\n", pKernelBaseBaseDllInitialize);
 
     void* pBaseNlsDllInitialize = nullptr;
     void* _;
@@ -189,16 +191,19 @@ NTSTATUS LeSetupAnsiOemCodeHashNodes() {
     if (pBaseNlsDllInitialize == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;
 
+    WriteLog(L"BaseNlsDllInitialize: %p\n", pBaseNlsDllInitialize);
+
     void* pNlsProcessInitialize = GetKthCallTarget(pBaseNlsDllInitialize, 0x30, 1);
     if (pNlsProcessInitialize == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;
+
+    WriteLog(L"NlsProcessInitialize: %p\n", pNlsProcessInitialize);
 
     auto the_func = (pSetupAnsiOemCodeHashNodes)GetKthCallTarget(pNlsProcessInitialize, 0x30, 3);
     if (the_func == nullptr)
         return STATUS_PROCEDURE_NOT_FOUND;
 
-    //AllocConsole();
-    //PrintConsoleW(L"SetupAnsiOemCodeHashNodes: %p\n", the_func);
+    WriteLog(L"SetupAnsiOemCodeHashNodes: %p\n", the_func);
 
     the_func();
 }
@@ -222,8 +227,7 @@ NTSTATUS LeGlobalData::HookKernel32Routines(PVOID Kernel32)
 
     Status = this->HackAnsiOemCodeHashNodes();
 
-    //AllocConsole();
-    //PrintConsoleW(L"hook k32: %p", Status);
+    WriteLog(L"hook k32: %p", Status);
 
     return Status;
 }

--- a/LocaleEmulator/LocaleEmulator.h
+++ b/LocaleEmulator/LocaleEmulator.h
@@ -608,7 +608,8 @@ public:
 
         struct
         {
-            BOOLEAN StockObjectInitialized : 1;
+            // maybe set up a flag for each kind of object?
+            //BOOLEAN StockObjectInitialized : 1;
 
             RTL_CRITICAL_SECTION GdiLock;
 

--- a/LocaleEmulator/LocaleEmulator.h
+++ b/LocaleEmulator/LocaleEmulator.h
@@ -523,9 +523,11 @@ protected:
     ml::GrowableArray<REGISTRY_REDIRECTION_ENTRY> RegistryRedirectionEntry;
     ml::HashTableT<TEXT_METRIC_INTERNAL> TextMetricCache;
 
+public:
     PVOID CodePageMapView;
     ULONG_PTR AnsiCodePageOffset, OemCodePageOffset, UnicodeCaseTableOffset;
 
+protected:
     PVOID DllNotificationCookie;
 
     UNICODE_STRING SystemDirectory;
@@ -544,6 +546,7 @@ public:
         API_POINTER(RtlKnownExceptionFilter)    StubRtlKnownExceptionFilter;
         API_POINTER(NtContinue)                 StubLdrInitNtContinue;
         API_POINTER(LdrResSearchResource)       StubLdrResSearchResource;
+        API_POINTER(RtlCustomCPToUnicodeN)      StubRtlCustomCPToUnicodeN;
 
         API_POINTER(NtUserMessageCall)          StubNtUserMessageCall;
         API_POINTER(NtUserDefSetText)           StubNtUserDefSetText;
@@ -587,12 +590,15 @@ public:
             RtlFreeUnicodeString(&Ntdll.CodePageKey);
             RtlFreeUnicodeString(&Ntdll.LanguageKey);
             RtlDeleteCriticalSection(&Gdi32.GdiLock);
+            RtlDeleteCriticalSection(&Ntdll.NtLock);
         }
 
         struct
         {
             UNICODE_STRING CodePageKey;
             UNICODE_STRING LanguageKey;
+
+            RTL_CRITICAL_SECTION NtLock;
 
         } Ntdll;
 
@@ -702,6 +708,7 @@ public:
 
     NTSTATUS HackUserDefaultLCID(PVOID Kernel32);
     NTSTATUS HackUserDefaultLCID2(PVOID Kernel32);
+    NTSTATUS HackAnsiOemCodeHashNodes();
     NTSTATUS InjectSelfToChildProcess(HANDLE Process, PCLIENT_ID Cid);
 
     /************************************************************************

--- a/LocaleEmulator/ml.cpp
+++ b/LocaleEmulator/ml.cpp
@@ -6966,16 +6966,6 @@ CreateFileInternalWithFullPath(
 
     static API_POINTER(ZwCreateFile) XCreateFile;
 
-/*#if ML_KERNEL_MODE
-
-    XCreateFile = ZwCreateFile;
-
-#else
-
-    XCreateFile = NtCreateFile;
-
-#endif*/
-
     if (XCreateFile == nullptr) {
 
         PLDR_MODULE Nt = FindLdrModuleByName(&USTR(L"ntdll.dll"));

--- a/LocaleEmulator/ml.cpp
+++ b/LocaleEmulator/ml.cpp
@@ -6964,9 +6964,9 @@ CreateFileInternalWithFullPath(
 */
     InitializeObjectAttributes(&ObjectAttributes, FileName, OBJ_CASE_INSENSITIVE, nullptr, nullptr);
 
-    API_POINTER(ZwCreateFile) XCreateFile;
+    static API_POINTER(ZwCreateFile) XCreateFile;
 
-#if ML_KERNEL_MODE
+/*#if ML_KERNEL_MODE
 
     XCreateFile = ZwCreateFile;
 
@@ -6974,7 +6974,14 @@ CreateFileInternalWithFullPath(
 
     XCreateFile = NtCreateFile;
 
-#endif
+#endif*/
+
+    if (XCreateFile == nullptr) {
+
+        PLDR_MODULE Nt = FindLdrModuleByName(&USTR(L"ntdll.dll"));
+
+        XCreateFile = (API_POINTER(ZwCreateFile))LookupExportTable(Nt->DllBase, NTDLL_NtCreateFile);
+    }
 
     Status = XCreateFile(
                 FileHandle,


### PR DESCRIPTION
## Description

The latest release seems to break down on some recent Windows 10 branches, including the latest Windows 10 insider preview 10.21390.2025 and 10.22000.132, aka. the preview for Windows 11. 

After some investigation, these major issues have been comfirmed on the prementioned versions:

1. The target application started by LEProc immediately crashes inside `CreateFontIndirectExW()`.
2. Even after resolving issue#1, `MultiByteToWideChar()` / `WideCharToMultiByte()` and `RtlMultiByteToUnicodeN()` do not give the desired result,  which affects `MBToWSCEx()` and further a bunch of common USER32 methods.
3. When one tries to run the target application as admin, it crashes due to an exception 0xC0000005. I noticed it is also mentioned in [the previous PR](https://github.com/xupefei/Locale-Emulator-Core/pull/2#issuecomment-478274299).

In this PR these issues have been resolved, at least on my test environments.
* 10.19042.746
* 10.21390.2025
* 10.22000.132

## Modifications Outline

Issue#1 seems due to the implementation change of `CreateFontIndirectExW()`, luckily the new implementation did not introduce new API dependencies, and previous implementations just work well. The PR contains an implementation from latest ReactOS, still, everything seems OK.

`RtlMultiByteToUnicodeN()` now depends on a new method `RtlpGetCodePageData()`, which involves some new global variables in NTDLL. It looks like that these new state variables are eventually only used by `RtlCustomCPToUnicodeN()`, so in the PR we choose to hijack the first argument `CustomCP` and rewrite this global structure. A slightly cleaner alternative approach could be first checking the presence of `RtlpGetCodePageData()` and hook it, but today both approaches are effectively equivalent.

As for `MultiByteToWideChar()`, actually API the implementation has no change, but it turns out that the global variables in KERNELBASE related to codepage are not rewritten to our desired values. (If I understand correctly, they should be rewritten by `HackUserDefaultLCID2()`? I have no idea why it no longer work...) In the PR we make use of `SetupAnsiOemCodeHashNodes()`, which is a method having existed for a long time. It fills up major codepage-related global variables according to some entries in the TEB, so we just rewrite TEB then invoke `SetupAnsiOemCodeHashNodes()`.

Issue#3, my investigation shows that when running as admin, the addresses of `NtCreateFile()` and `ZwCreateFile()` in the IAT of `LocaleEmulator.dll` become some erroneous values. I don't know why, but loading these two methods dynamically solves the problem. 